### PR TITLE
Feature #2533.

### DIFF
--- a/apps/opencs/model/settings/usersettings.cpp
+++ b/apps/opencs/model/settings/usersettings.cpp
@@ -143,6 +143,16 @@ void CSMSettings::UserSettings::buildSettingModelDefaults()
         minWidth->setDefaultValue (325);
         minWidth->setRange (50, 10000);
         minWidth->setToolTip ("Minimum width of subviews.");
+
+        Setting *saveState = createSetting (Type_CheckBox, "save-state", "Save window size and position");
+        saveState->setDefaultValue ("true");
+        saveState->setToolTip ("Remember window size and position between editing sessions.");
+
+        Setting *saveX = createSetting (Type_CheckBox, "x-save-state-workaround", "X windows workaround");
+        saveX->setDefaultValue ("false");
+        saveX->setToolTip ("Some X window managers don't remember the windows state before being"
+            " maximized. In such environments exiting while maximized will correctly start in a maximized"
+            " window, but restoring back to the normal size won't work.  Try this workaround.");
     }
 
     declareSection ("records", "Records");
@@ -456,6 +466,21 @@ QString CSMSettings::UserSettings::setting(const QString &viewKey, const QString
     }
 
     return QString();
+}
+
+QVariant CSMSettings::UserSettings::value(const QString &viewKey, const QVariant &value)
+{
+    if(value != QVariant())
+    {
+        mSettingDefinitions->setValue (viewKey, value);
+        return value;
+    }
+    else if(mSettingDefinitions->contains(viewKey))
+    {
+        return mSettingDefinitions->value (viewKey);
+    }
+
+    return QVariant();
 }
 
 bool CSMSettings::UserSettings::hasSettingDefinitions (const QString &viewKey) const

--- a/apps/opencs/model/settings/usersettings.hpp
+++ b/apps/opencs/model/settings/usersettings.hpp
@@ -82,6 +82,8 @@ namespace CSMSettings {
 
         QString setting(const QString &viewKey, const QString &value = QString());
 
+        QVariant value(const QString &viewKey, const QVariant &value = QVariant());
+
     private:
 
         void buildSettingModelDefaults();

--- a/apps/opencs/view/doc/operations.cpp
+++ b/apps/opencs/view/doc/operations.cpp
@@ -19,6 +19,7 @@ CSVDoc::Operations::Operations()
     setVisible (false);
     setFixedHeight (widgetContainer->height());
     setTitleBarWidget (new QWidget (this));
+    setObjectName (QString("operations")); // needed to suppress warning while saving window state
 }
 
 void CSVDoc::Operations::setProgress (int current, int max, int type, int threads)

--- a/apps/opencs/view/doc/subview.cpp
+++ b/apps/opencs/view/doc/subview.cpp
@@ -8,6 +8,8 @@ CSVDoc::SubView::SubView (const CSMWorld::UniversalId& id)
     /// \todo  add a button to the title bar that clones this sub view
 
     setWindowTitle (QString::fromUtf8 (mUniversalId.toString().c_str()));
+    // set object name to suppress warning while saving window state
+    setObjectName (QString::fromUtf8 (mUniversalId.toString().c_str()));
     setAttribute(Qt::WA_DeleteOnClose);
 }
 

--- a/apps/opencs/view/doc/view.hpp
+++ b/apps/opencs/view/doc/view.hpp
@@ -48,6 +48,9 @@ namespace CSVDoc
             QMainWindow mSubViewWindow;
             GlobalDebugProfileMenu *mGlobalDebugProfileMenu;
 
+            bool mSaveWindowState;
+            bool mXWorkaround;
+
 
             // not implemented
             View (const View&);
@@ -111,6 +114,11 @@ namespace CSVDoc
 
             /// Function called by view manager when user preferences are updated
             void updateEditorSetting (const QString &, const QString &);
+
+        protected:
+
+            virtual void moveEvent(QMoveEvent * event);
+            virtual void resizeEvent(QResizeEvent * event);
 
         signals:
 
@@ -228,6 +236,8 @@ namespace CSVDoc
             void stop();
 
             void closeRequest (SubView *subView);
+
+            void saveWindowState();
     };
 }
 

--- a/apps/opencs/view/doc/viewmanager.cpp
+++ b/apps/opencs/view/doc/viewmanager.cpp
@@ -405,6 +405,27 @@ bool CSVDoc::ViewManager::removeDocument (CSVDoc::View *view)
             else
                 remainingViews.push_back(*iter);
         }
+
+        // FIXME: seems removeDocument() and closeRequest() are duplicated functionality
+        CSMSettings::UserSettings &userSettings = CSMSettings::UserSettings::instance();
+        if (remainingViews.empty() && !mViews.empty() &&
+            userSettings.settingValue ("window/save-state").toStdString() == "true")
+        {
+            if (userSettings.settingValue ("window/x-save-state-workaround").toStdString() == "true"
+                    && mViews.back()->isMaximized())
+            {
+                userSettings.setDefinitions("window/maximized", (QStringList() << "true"));
+                userSettings.saveDefinitions(); // store previously saved geometry & state
+            }
+            else
+            {
+                userSettings.value("window/geometry", mViews.back()->saveGeometry());
+                userSettings.value("window/state", mViews.back()->saveState());
+                userSettings.setDefinitions("window/maximized", (QStringList() << "false"));
+                userSettings.saveDefinitions();
+            }
+        }
+
         mDocumentManager.removeDocument(document);
         mViews = remainingViews;
     }


### PR DESCRIPTION
  Similar but less complete implementation PR was not accepted (see https://github.com/OpenMW/openmw/pull/276#issuecomment-57612802).

- User preferences setting to save the window state (position, geometry, etc) at the time of exit.
- User preferences setting to workaround some X window managers not keeping pre-maximised state.
- Uses opencs.ini to store window states between sessions.